### PR TITLE
Dynamic execs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +488,7 @@ dependencies = [
  "clap",
  "get_if_addrs",
  "gethostname",
+ "home",
  "serde",
  "tempdir",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "0.6"
 clap = "2"
 get_if_addrs = "0.5"
 gethostname = "0"
+home = "0.5"
 serde = { version = "1", features = ["derive"] }
 tempdir = "0.3"
 # TODO: Reduce feature set

--- a/spraycc.toml
+++ b/spraycc.toml
@@ -1,0 +1,27 @@
+
+# Executor options
+[exec]
+# Number of executors to start initially
+initial_count = 5
+# Maximum number of executors to keep running at one. Set to 'initial_count' to have all submitted at once.
+max_count = 200
+# Number of submitted, but not yet connected executors. This plus submit delays determins how fast the
+# cloud of executors increases fron initial_count to max_count.
+keep_pending = 3
+# Delay from last submitted task until idle executors are released
+release_delay = 30
+# Shutdown after idle for N seconds
+idle_shutdown_after = 60
+# Command used to start new executors. Options such as --callme will be appended.
+start_cmd = "bsub -q pegasus -n 1 -R 'rusage[mem=10GB]' -W 1:0 /home/jasonm/packages/spraycc/spraycc"
+
+
+[command.runqa]
+command = "runqa.sh"
+env_vars = ["GEOM_HOME", "FRED"]
+output_files = []
+
+[command.gcc]
+command = ["gcc", "g++", "clang"]
+output_files = ["after", "-o", "after", "-MF"]
+run_local_if = ["not_exists", ["-c", "-s", "-e", "-MD"]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,9 +32,9 @@ pub struct ExecConfig {
     /// Number of exec's pending as count climbs towards max
     pub keep_pending: usize,
     /// Idle delay when no more task have arrived to start releasing idle exec's
-    pub release_delay: usize,
+    pub release_delay: u64,
     /// Idle delay when no tasks are running or arriving to shutdown server
-    pub idle_shutdown_after: usize,
+    pub idle_shutdown_after: u64,
     /// Command to use to start exec processes
     pub start_cmd: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,79 @@
+extern crate home;
 extern crate toml;
 
+use super::ipc;
+use serde::Deserialize;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Result, Write};
 use std::path::{Path, PathBuf};
 
-use super::ipc;
-
 const CONNECT_FILE: &str = ".spraycc-server";
+
+#[derive(Deserialize, Debug)]
+struct ConfigWrapper {
+    exec: ExecConfig,
+    command: std::collections::HashMap<String, toml::map::Map<String, toml::Value>>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct CmdConfig {
+    command: Vec<String>,
+    output_files: Option<Vec<String>>,
+}
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
+pub struct ExecConfig {
+    /// Number of execs to start immediately
+    pub initial_count: usize,
+    /// Maximum number of execs to start if there are enough tasks
+    pub max_count: usize,
+    /// Number of exec's pending as count climbs towards max
+    pub keep_pending: usize,
+    /// Idle delay when no more task have arrived to start releasing idle exec's
+    pub release_delay: usize,
+    /// Idle delay when no tasks are running or arriving to shutdown server
+    pub idle_shutdown_after: usize,
+    /// Command to use to start exec processes
+    pub start_cmd: String,
+}
+
+impl Default for ExecConfig {
+    fn default() -> Self {
+        ExecConfig {
+            initial_count: 5,
+            max_count: 1000,
+            keep_pending: 5,
+            release_delay: 30,
+            idle_shutdown_after: 60,
+            start_cmd: "spraycc".to_string(), // TODO: lookup up path to this process
+        }
+    }
+}
+
+/// Reads a configuration file and returns the config object
+pub fn load_config_file() -> ExecConfig {
+    if let Ok(config) = load_config_file_internal(&PathBuf::from(".spraycc")) {
+        return config;
+    } else if let Some(mut home_dir) = home::home_dir() {
+        home_dir.push(".spraycc");
+        if let Ok(config) = load_config_file_internal(&home_dir) {
+            return config;
+        }
+    }
+    ExecConfig::default()
+}
+
+fn load_config_file_internal(path: &PathBuf) -> Result<ExecConfig> {
+    let mut f = OpenOptions::new().read(true).open(&path)?;
+    let mut buf = String::new();
+    f.read_to_string(&mut buf)?;
+
+    let config: ConfigWrapper = toml::from_str(&buf)?;
+    println!("Read config file from {}", path.to_string_lossy());
+    Ok(config.exec)
+}
 
 /// Write a configuration file describing the post and port the server is listening on and
 /// the access code a client process should use.

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -55,7 +55,7 @@ pub async fn run(callme: ipc::CallMe) -> Result<(), Box<dyn Error + Send + Sync>
 }
 
 async fn handle_new_task(conn: &mut ipc::Connection, details: ipc::TaskDetails) -> Result<(), Box<dyn Error + Send + Sync>> {
-    println!("Got task {:?}", details);
+    // println!("Got task {:?}", details);
     match Task::start(&details.working_dir, &details.cmd, details.args, &details.output_args) {
         Ok(task) => run_task(conn, task).await,
         Err(err) => {
@@ -78,7 +78,7 @@ async fn run_task(conn: &mut ipc::Connection, mut task: Task) -> Result<(), Box<
                 if let Ok(None) = line_res {
                     stdout_done = true;
                 } else if let Ok(Some(mut line)) = line_res {
-                    println!("Got stdout: {}", &line);
+                    // println!("Got stdout: {}", &line);
                     line.push('\n');
                     conn.write_message(&ipc::Message::TaskOutput { output_type : ipc::OutputType::Stdout, content : Vec::from(line) }).await?;
 
@@ -104,13 +104,13 @@ async fn run_task(conn: &mut ipc::Connection, mut task: Task) -> Result<(), Box<
     // Child should have exited if stdout and stderr are closed
     let status = task.child.wait().await?;
 
-    println!("Sending {} output files", task.output_files.len());
+    // println!("Sending {} output files", task.output_files.len());
     for (idx, generated_file) in task.output_files.iter().enumerate() {
         send_output_file(conn, ipc::OutputType::File(idx), &generated_file).await?;
     }
 
     conn.write_message(&ipc::Message::TaskDone { exit_code: status.code() }).await?;
-    println!("Status = {:?}", status);
+    // println!("Status = {:?}", status);
     Ok(())
 }
 
@@ -119,7 +119,7 @@ async fn send_output_file(conn: &mut ipc::Connection, output_type: ipc::OutputTy
     // Ignore file open errors, these are typically due to compiler errors. No output is sent, which indicates the file should not
     // be created on the other end.
     if let Ok(mut fs) = tokio::fs::OpenOptions::new().read(true).open(path.as_os_str()).await {
-        println!("Sending output file {}", path.to_string_lossy());
+        // println!("Sending output file {}", path.to_string_lossy());
         loop {
             let mut buf: Vec<u8> = vec![0; 65536];
             let n = fs.read(buf.as_mut_slice()).await?;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -96,9 +96,6 @@ pub enum Message {
         exit_code: Option<i32>,
     },
 
-    /// Indicates the server can assume no more tasks are coming (within some bounds of a race condition w/ timing)
-    LastTaskSent,
-
     // A specific task should be canceled
     CancelTask,
 
@@ -125,7 +122,6 @@ impl fmt::Debug for Message {
             },
             Message::TaskFailed { error_message } => write!(f, "TaskDone, error: {}", error_message),
             Message::TaskDone { exit_code } => write!(f, "TaskDone, exit code {}", exit_code.unwrap_or(-1)),
-            Message::LastTaskSent => write!(f, "LastTaskSend"),
             Message::CancelTask => write!(f, "CancelTask"),
             Message::PissOff => write!(f, "PissOff"),
             Message::Dropped => write!(f, "Dropped"),

--- a/src/task.rs
+++ b/src/task.rs
@@ -109,7 +109,7 @@ fn generate_unique_file(output_dir: &TempDir, taken_names: &mut HashSet<String>,
 
 /// Starts a task in the specified directory and retuns the child process object.
 fn start_task(dir: &Path, cmd: &Path, args: &[String]) -> process::Child {
-    println!("Starting task {:?} in dir {:?}, args={:?}", cmd, dir, args);
+    // println!("Starting task {:?} in dir {:?}, args={:?}", cmd, dir, args);
     process::Command::new(cmd)
         .args(args[1..].iter())
         .current_dir(dir)


### PR DESCRIPTION
Added .spraycc config file specifying server settings such as how many exec engines to use
Dynamically add exec engines
Dynamically release exec engines when idle
Automatic shutdown of server if idle
Cleaned up logging
