### PR TITLE
Perf improvements, other cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "tempdir",
  "tokio",
  "toml",
+ "ubyte",
  "which",
 ]
 
@@ -704,6 +705,10 @@ checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "ubyte"
+version = "0.10.1"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ tempdir = "0.3"
 # TODO: Reduce feature set
 tokio = { version = "0.3", features = ["full"] }
 toml = "0.5"
+ubyte = { path = "../ubyte" }
 which = "2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -138,7 +138,11 @@ async fn handle_msg(output_files: &mut Vec<LazyFile>, msg: ipc::Message) -> Resu
             println!("Task failed: {}", error_message);
             Ok(Some(-1))
         }
-        ipc::Message::TaskDone { exit_code } => {
+        ipc::Message::TaskDone {
+            exit_code,
+            run_time: _,
+            send_time: _,
+        } => {
             // println!("Task done, exited with {:?}", exit_code);
             Ok(exit_code)
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,8 @@ pub struct ExecConfig {
     pub idle_shutdown_after: u64,
     /// Command to use to start exec processes
     pub start_cmd: String,
+    /// Alternate start command
+    pub alt_start_cmd: Option<String>,
 }
 
 impl Default for ExecConfig {
@@ -48,6 +50,7 @@ impl Default for ExecConfig {
             release_delay: 30,
             idle_shutdown_after: 60,
             start_cmd: "spraycc".to_string(), // TODO: lookup up path to this process
+            alt_start_cmd: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,7 @@ fn load_config_file_internal(path: &PathBuf) -> Result<ExecConfig> {
         Ok(config) => Ok(config),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Err(err),
         Err(err) => {
-            println!("Error reading configuration file {}:\n   {}", path.to_string_lossy(), err);
+            println!("SprayCC: Error reading configuration file {}:\n   {}", path.to_string_lossy(), err);
             Err(err)
         }
     }
@@ -102,7 +102,7 @@ fn read_config_file(path: &PathBuf) -> Result<ExecConfig> {
     f.read_to_string(&mut buf)?;
 
     let config: ConfigWrapper = toml::from_str(&buf)?;
-    println!("Read config file from {}", path.to_string_lossy());
+    println!("SprayCC: Read config file from {}", path.to_string_lossy());
     Ok(config.exec)
 }
 
@@ -124,19 +124,18 @@ pub fn read_server_contact_info() -> Option<ipc::CallMe> {
 
 fn read_server_contact_info_from(mut p: PathBuf) -> Option<ipc::CallMe> {
     p.push(CONNECT_FILE);
-    // println!("Checking directory {}", p.to_string_lossy());
     if p.exists() {
         match OpenOptions::new().read(true).open(&p) {
             Ok(mut f) => deserialize_contact_info(&p, &mut f),
             Err(e) => {
-                println!("Unable to open server config file {}: {}", p.to_string_lossy(), e);
+                println!("SprayCC: Unable to open server config file {}: {}", p.to_string_lossy(), e);
                 None
             }
         }
     } else if p.pop() && p.pop() {
         read_server_contact_info_from(p)
     } else {
-        println!("No server config file found in this directory or any parent directory");
+        println!("SprayCC: No server config file found in this directory or any parent directory");
         None
     }
 }
@@ -147,12 +146,12 @@ fn deserialize_contact_info(p: &PathBuf, f: &mut File) -> Option<ipc::CallMe> {
         Ok(_) => match toml::from_str::<ipc::CallMe>(&buf) {
             Ok(config) => Some(config),
             Err(e) => {
-                println!("Error deserializing server config file {}; {}", p.to_string_lossy(), e);
+                println!("SprayCC: Error deserializing server config file {}; {}", p.to_string_lossy(), e);
                 None
             }
         },
         Err(e) => {
-            println!("Error reading server config file {}: {}", p.to_string_lossy(), e);
+            println!("SprayCC: Error reading server config file {}: {}", p.to_string_lossy(), e);
             None
         }
     }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -64,10 +64,10 @@ pub struct TaskDetails {
 
 /// Messages sent between Spraycc processes.
 /// *C++*: This could be done as a trait (interface / base class) or as an enum (enum + struct). A trait
-/// would be more common in open systems the set of messages needs to be extened without requiring a
+/// would be more common in open systems so set of messages can be extened without requiring a
 /// recompile of the whole system (any module can add a new implementation of the interface). I went with
 /// an enum here becaause it's a closed system with a small set of messages so it's nice to have the compiler
-/// validate that every message type is handled. And it's way to experiment with Rust enum's.
+/// validate that every message type is handled. And it's a way to experiment with Rust enum's.
 #[derive(Serialize, Deserialize, Clone)]
 pub enum Message {
     /// Executor is ready, sends access code


### PR DESCRIPTION
Messages are boxed to reduce copying in queues, seems to reduce CPU time a little w/ heavy results traffic
Port number is now assigned by OS to allow multiple servers per host
Records transfer rate, total network transit, and run & results send time in prep for keeping runtime history
