### PR TITLE
Implemented -b/--both to submit to both primary and alternate queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "lock_api"
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if",
  "instant",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -535,9 +535,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ gethostname = "0"
 home = "0.5"
 lazy_static = "1"
 rand = "^0.8"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "^1", features = ["derive"] }
 simple-process-stats = "^1"
 tempdir = "0.3"
 # TODO: Reduce feature set

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -25,7 +25,10 @@ use std::error::Error;
 pub async fn run(callme: ipc::CallMe) -> Result<(), Box<dyn Error + Send + Sync>> {
     let stream = TcpStream::connect(callme.addr).await?;
     let mut conn = ipc::Connection::new(stream);
-    conn.write_message(&ipc::Message::YourObedientServant { access_code: 42 }).await?;
+    conn.write_message(&ipc::Message::YourObedientServant {
+        access_code: callme.access_code,
+    })
+    .await?;
 
     loop {
         match conn.read_message().await? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ async fn main() {
     let res: Result<(), Box<dyn Error + Send + Sync>> = if let Some(server) = matches.subcommand_matches("server") {
         let max_cpus = match server.value_of("max_cpus").map(|v| v.parse::<usize>()) {
             Some(Ok(v)) if v > 0 => Some(v),
-            Some(Ok(_)) | Some(Err(_)) => panic!("Invalid --cpus argument '{}', must be a positive integer"),
+            Some(Ok(_)) | Some(Err(_)) => panic!("Invalid --cpus argument, must be a positive integer"),
             None => None,
         };
         let both_start_cmds = server.is_present("both_queues");

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,16 @@ async fn main() {
                     Arg::with_name("alt_start_cmd")
                         .short("a")
                         .long("alt")
-                        .help("Use alt_start_cmd from .spraycc"),
-                ),
+                        .help("Use alt_start_cmd from .spraycc")
+                        .conflicts_with("both_queues"),
+                )
+                .arg(
+                    Arg::with_name("both_queues")
+                        .short("b")
+                        .long("both")
+                        .help("Submit jobs using both start commands"),
+                )
+                .arg(Arg::with_name("verbose").short("v").long("verbose").help("Verbose server logging")),
         )
         .subcommand(
             SubCommand::with_name("run")
@@ -95,9 +103,11 @@ async fn main() {
             Some(Ok(_)) | Some(Err(_)) => panic!("Invalid --cpus argument '{}', must be a positive integer"),
             None => None,
         };
-        let alt_start_cmd = server.is_present("alt_start_cmd");
+        let both_start_cmds = server.is_present("both_queues");
+        let alt_start_cmd = server.is_present("alt_start_cmd") && !both_start_cmds;
+        let verbose = server.is_present("verbose");
 
-        server::run(max_cpus, alt_start_cmd).await
+        server::run(max_cpus, alt_start_cmd, both_start_cmds, verbose).await
     } else if let Some(exec) = matches.subcommand_matches("exec") {
         assert!(exec.is_present("callme") && exec.is_present("access_code"));
         let addr = exec.value_of("callme").unwrap();


### PR DESCRIPTION
-b / --both submits executors using both start_cmd and alt_start_cmd, half pending for both. Additional executors are started using either command based on the start rate. Thus jobs flow to whichever queue has availability.

Finally implemented access code for rejecting incorrect clients. Also happens to be useful for determining which queue a given executor is from.

Added --verbose for monitoring the server.

Hopefully finally fixed the watchdog timer.