### PR TITLE
History recording - WIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +549,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -582,6 +605,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "serde",
+ "serde_json",
  "simple-process-stats",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,12 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,26 +451,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.2",
+ "rand_core",
  "rand_hc",
 ]
 
@@ -487,23 +468,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -520,16 +486,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.2",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -623,10 +580,10 @@ dependencies = [
  "gethostname",
  "home",
  "lazy_static",
- "rand 0.8.3",
+ "rand",
  "serde",
  "simple-process-stats",
- "tempdir",
+ "tempfile",
  "tokio",
  "toml",
  "ubyte",
@@ -651,13 +608,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
+name = "tempfile"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "rand 0.4.6",
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
  "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "spraycc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -421,6 +437,16 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "priority-queue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1340009a04e81f656a4e45e295f0b1191c81de424bf940c865e33577a8e223"
+dependencies = [
+ "autocfg",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -603,6 +629,7 @@ dependencies = [
  "gethostname",
  "home",
  "lazy_static",
+ "priority-queue",
  "rand",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ get_if_addrs = "0.5"
 gethostname = "0"
 home = "0.5"
 lazy_static = "1"
+priority-queue = "^1.1"
 rand = "^0.8"
 serde = { version = "^1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ home = "0.5"
 lazy_static = "1"
 rand = "^0.8"
 serde = { version = "^1", features = ["derive"] }
+serde_json = "1"
 simple-process-stats = "^1"
 tempfile = "^3.2"
 # TODO: Reduce feature set

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1"
 rand = "^0.8"
 serde = { version = "^1", features = ["derive"] }
 simple-process-stats = "^1"
-tempdir = "0.3"
+tempfile = "^3.2"
 # TODO: Reduce feature set
 tokio = { version = "^1.2", features = ["full"] }
 toml = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spraycc"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jason McCampbell <jasonmccampbell@gmail.com>"]
 edition = "2018"
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,6 +161,7 @@ async fn handle_msg(output_files: &mut Vec<LazyFile>, msg: ipc::Message) -> Resu
         }
         ipc::Message::TaskDone {
             exit_code,
+            target_id: _,
             run_time: _,
             send_time: _,
         } => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -226,13 +226,13 @@ fn interpret_command_line(args: Vec<String>) -> Result<(bool, ipc::TaskDetails),
         Ok(cmd) => {
             let cmd_name = cmd.file_name().map(|s| s.to_string_lossy()).unwrap(); // Can this fail if path exists?
 
-            let (keep_local, output_args) = {
+            let (keep_local, priority_task, output_args) = {
                 if cmd_name == "gcc" || cmd_name == "g++" || cmd_name == "clang" {
                     handle_gnu(&args)
                 } else if cmd_name == "echo" || cmd_name == "ls" {
-                    (false, Vec::new())
+                    (false, false, Vec::new())
                 } else {
-                    (false, Vec::new())
+                    (false, false, Vec::new())
                 }
             };
 
@@ -247,6 +247,7 @@ fn interpret_command_line(args: Vec<String>) -> Result<(bool, ipc::TaskDetails),
                         args,
                         output_args,
                         env,
+                        priority_task,
                     },
                 ))
             } else {
@@ -259,11 +260,12 @@ fn interpret_command_line(args: Vec<String>) -> Result<(bool, ipc::TaskDetails),
 
 /// TODO: Replace with a user-configurable data structure which describes the various compilers and other executes
 /// which may be used.
-fn handle_gnu(args: &[String]) -> (bool, Vec<u16>) {
+fn handle_gnu(args: &[String]) -> (bool, bool, Vec<u16>) {
     // -o and -MF specify output file names.
     // -c, -s, -E, and -MD (dependency generation) are compilation of various sorts and should be remoted; lacking
     // those are linking which is kept local
     let mut keep_local = true;
+    let mut priority_task = false;
     let mut output_idxs: Vec<u16> = Vec::new();
     for idx in 1..args.len() {
         let arg = &args[idx];
@@ -271,9 +273,12 @@ fn handle_gnu(args: &[String]) -> (bool, Vec<u16>) {
             keep_local = false;
         } else if idx < args.len() - 1 && (arg == "-o" || arg == "-MF") {
             output_idxs.push((idx + 1) as u16);
+        } else if arg == "-M" || arg == "-MM" {
+            keep_local = false;
+            priority_task = true; // Dependency generation only
         }
     }
-    (keep_local, output_idxs)
+    (keep_local, priority_task, output_idxs)
 }
 
 #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -105,6 +105,7 @@ pub async fn run(args: Vec<String>) -> Result<i32, Box<dyn Error + Send + Sync>>
                 while !output_files.is_empty() {
                     output_files.pop().unwrap().shutdown().await?
                 }
+                conn.shutdown().await;
             }
             Err(_) => {
                 status = Some(-1);

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,5 +1,3 @@
-extern crate tempdir;
-
 ///
 /// The executor processes are submitted to the farm and then pull jobs from the
 /// server, execute them, and return the results. The process goes away when told
@@ -55,6 +53,7 @@ pub async fn run(callme: ipc::CallMe) -> Result<(), Box<dyn Error + Send + Sync>
         }
         conn.flush().await?;
     }
+    conn.shutdown().await;
     Ok(())
 }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -58,8 +58,9 @@ pub async fn run(callme: ipc::CallMe) -> Result<(), Box<dyn Error + Send + Sync>
 }
 
 async fn handle_new_task(conn: &mut ipc::Connection, details: ipc::TaskDetails) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let target_id = details.get_target_id();
     match Task::start(&details.working_dir, &details.cmd, details.args, &details.output_args, &details.env) {
-        Ok(task) => run_task(conn, task).await,
+        Ok(task) => run_task(conn, task, target_id).await,
         Err(err) => {
             conn.write_message(&ipc::Message::TaskFailed { error_message: err }).await?;
             Ok(())
@@ -67,7 +68,7 @@ async fn handle_new_task(conn: &mut ipc::Connection, details: ipc::TaskDetails) 
     }
 }
 
-async fn run_task(conn: &mut ipc::Connection, mut task: Task) -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn run_task(conn: &mut ipc::Connection, mut task: Task, target_id: String) -> Result<(), Box<dyn Error + Send + Sync>> {
     let start_time = time::Instant::now();
     let mut stdout_reader = BufReader::new(task.child.stdout.take().unwrap()).lines();
     let mut stderr_reader = BufReader::new(task.child.stderr.take().unwrap()).lines();
@@ -114,6 +115,7 @@ async fn run_task(conn: &mut ipc::Connection, mut task: Task) -> Result<(), Box<
 
     conn.write_message(&ipc::Message::TaskDone {
         exit_code: status.code(),
+        target_id,
         run_time: task_finish - start_time,
         send_time: send_finish - task_finish,
     })

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,112 @@
+extern crate home;
+
+use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Result, Write};
+use std::path::{Path, PathBuf};
+use std::time;
+use std::{collections::HashMap, net::ToSocketAddrs};
+use tempfile::tempfile;
+
+/// Maps a unique target (output file, command line, etc) to a pair of the prior elapsed time for that task.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct History {
+    version: u32,
+    /// Map target internally is a duration (elapsed of the task) and the time when it was recorded to
+    /// allow stale entries to be flushed.
+    history: HashMap<String, (time::Duration, time::SystemTime)>,
+}
+
+impl History {
+    /// Constructs a new, empty history for the server to record into
+    pub fn new() -> History {
+        History {
+            version: 1,
+            history: HashMap::new(),
+        }
+    }
+
+    /// Returns the runtime for task
+    pub fn get(self: &History, target: &str) -> Option<time::Duration> {
+        self.history.get(target).map(|v| (*v).0)
+    }
+
+    /// Update the record with a new entry. Any existing entry is replaced.
+    pub fn update(self: &mut History, target: &str, elapsed: time::Duration) {
+        self.history.insert(target.to_string(), (elapsed, time::SystemTime::now()));
+    }
+
+    /// Update 'self' with the more recent entries from the incoming history
+    fn merge(self: &mut History, incoming: History) {
+        self.history.extend(incoming.history);
+    }
+}
+
+/// Reads the current history, returning an empty History object if no data are present.
+pub fn load_current_history() -> History {
+    if let Some(mut home_dir) = home::home_dir() {
+        if let Ok(history) = load_history_internal(&path_to_history(&home_dir)) {
+            return history;
+        }
+    }
+    History::new()
+}
+
+/// Loads the history at the given location and returns the History instance or reports a warning to the
+/// user if the file exists and isn't readable. History is optional so the expectation is things move ahead
+/// with an empty one.
+fn load_history_internal(path: &PathBuf) -> Result<History> {
+    match read_history_file(path) {
+        Ok(history) => Ok(history),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Err(err),
+        Err(err) => {
+            println!(
+                "SprayCC: Warning reading existing history (ignored) {}:\n   {}",
+                path.to_string_lossy(),
+                err
+            );
+            Err(err)
+        }
+    }
+}
+
+/// Low-level history file reader.
+fn read_history_file(path: &PathBuf) -> Result<History> {
+    let mut f = OpenOptions::new().read(true).open(&path)?;
+    let mut buf = String::new();
+    f.read_to_string(&mut buf)?;
+
+    let history: History = toml::from_str(&buf)?;
+    println!("SprayCC: Read history file from {}", path.to_string_lossy());
+    Ok(history)
+}
+
+/// Writes the history to a unique, temporary file next to the real history and, once complete, renames
+/// the temporary file to the final name. This avoids potential cases where the history is updated by
+/// two servers at the same time.
+fn write_history_file(history: &History) -> Result<()> {
+    if let Some(home_dir) = home::home_dir() {
+        let tmppath = unique_history_path(&home_dir);
+        let mut f = File::open(&tmppath)?;
+        if let Ok(data) = toml::to_vec(history) {
+            f.write_all(&data[..])?;
+            drop(f);
+
+            std::fs::rename(tmppath, home_dir.join(".spraycc.history"))?;
+        } else {
+            println!("SprayCC: Internal error while serializing history data");
+        }
+    } else {
+        println!("SprayCC: Unable to get user home directory, history not saved");
+    }
+    Ok(())
+}
+
+fn unique_history_path(path: &PathBuf) -> PathBuf {
+    // TODO: Not likely to be unique
+    path.join(".spraycc.history.5")
+}
+
+fn path_to_history(path: &PathBuf) -> PathBuf {
+    path.join(".spraycc.history")
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -58,7 +58,9 @@ impl Default for History {
 /// Reads the current history, returning an empty History object if no data are present.
 pub fn load_current_history() -> History {
     if let Some(home_dir) = home::home_dir() {
-        if let Ok(history) = load_history_internal(&path_to_history(&home_dir)) {
+        let pth = path_to_history(&home_dir);
+        if let Ok(history) = load_history_internal(&pth) {
+            println!("SprayCC: Read history file from {}", pth.to_string_lossy());
             return history;
         }
     }
@@ -90,7 +92,6 @@ fn read_history_file(path: &PathBuf) -> Result<History> {
     f.read_to_string(&mut buf)?;
 
     let history: History = serde_json::from_str(&buf)?;
-    println!("SprayCC: Read history file from {}", path.to_string_lossy());
     Ok(history)
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -354,6 +354,7 @@ fn test_task_details_target() {
             .collect(),
         output_args: vec![2u16],
         env: env.clone(),
+        priority_task: false,
     };
     let t1_target = t1.get_target_id();
 
@@ -366,6 +367,7 @@ fn test_task_details_target() {
             .collect(),
         output_args: vec![2u16, 3u16],
         env: env.clone(),
+        priority_task: false,
     };
     let t2_target = t2.get_target_id();
 
@@ -378,6 +380,7 @@ fn test_task_details_target() {
             .collect(),
         output_args: vec![5u16],
         env: env.clone(),
+        priority_task: false,
     };
     let t3_target = t3.get_target_id();
 
@@ -389,6 +392,7 @@ fn test_task_details_target() {
         args: vec!["run_test", "-test-name", "test1"].iter().map(|s| (**s).to_string()).collect(),
         output_args: vec![],
         env: env.clone(),
+        priority_task: false,
     };
     let t4_target = t4.get_target_id();
 
@@ -401,6 +405,7 @@ fn test_task_details_target() {
             .collect(),
         output_args: vec![],
         env: env.clone(),
+        priority_task: false,
     };
     let t5_target = t5.get_target_id();
 
@@ -414,6 +419,7 @@ fn test_task_details_target() {
         args: vec!["run_test", "-test_name", "test1"].iter().map(|s| (**s).to_string()).collect(),
         output_args: vec![],
         env: env.clone(),
+        priority_task: true,
     };
     let t6_target = t6.get_target_id();
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -205,9 +205,8 @@ impl Connection {
         Ok(())
     }
 
-    pub async fn shutdown(&mut self) -> Result<()> {
-        self.stream.shutdown().await?;
-        Ok(())
+    pub async fn shutdown(&mut self) {
+        let _ = self.stream.shutdown().await;
     }
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -273,7 +273,7 @@ async fn test_msgs() {
             None => break,
         }
     }
-    conn.shutdown().await.unwrap();
+    conn.shutdown().await;
     assert_eq!(msgs_recvd, 4);
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -61,6 +61,9 @@ pub struct TaskDetails {
     pub output_args: Vec<u16>,
     /// Environment variables to be propagated to the execution host
     pub env: HashMap<String, String>,
+    /// Hint that the task should be given high priority relative to other tasks. Ex: dependency generation
+    /// tasks which must complete before others can start.
+    pub priority_task: bool,
 }
 
 impl TaskDetails {
@@ -228,6 +231,7 @@ impl Connection {
         // May get more than a full message, that is ok. A partial message indicates that the connection
         // was broken prematurely.
         if self.buf.len() >= msg_size {
+            // TODO: This could panic if garbage comes in. bincode have a non-panic mechanism?
             let msg = bincode::deserialize(self.buf.as_ref()).expect("Unable to decode message");
             self.buf.advance(msg_size);
             Ok(Some(msg))

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ pub mod task;
 #[tokio::main]
 async fn main() {
     let matches = App::new("SprayCC")
-        .version("0.8.0")
+        .version("0.9.0")
         .about("SprayCC - distributed compiler wrapper")
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ mod config;
 /// # exec
 /// Module implementing the 'exec' subcommand
 mod exec;
+/// # history
+/// Module implementing a history of the elapsed time for each target
+pub mod history;
 /// # ipc
 /// Inter-process communication utilities, mostly focused on message passing
 mod ipc;

--- a/src/server.rs
+++ b/src/server.rs
@@ -238,8 +238,11 @@ impl ServerState {
     /// a task. Queue processing is done as a part of this function, so the submitted task may be sent out immediately
     /// or queued for later processing.
     async fn remote_is_client(self: &mut ServerState, conn_id: usize, details: ipc::TaskDetails) -> Result<(), Box<dyn Error + Send + Sync>> {
+        // Priority tasks get a bump. 300 == over a 5-minute long task
+        let priority = Duration::from_secs(if details.priority_task { 300 } else { 0 });
+
         let target_id = details.get_target_id();
-        let prior = self.prior_history.get(&target_id).unwrap_or(Duration::from_secs(1));
+        let prior = self.prior_history.get(&target_id).unwrap_or(Duration::from_secs(1)) + priority;
         if self.verbose {
             println!("SprayCC: received task {} priority={:?}", &target_id, prior);
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,6 +19,7 @@ use tokio::time::{Duration, Instant};
 use ubyte::{ByteUnit, ToByteUnit};
 
 use super::config::{load_config_file, write_server_contact_info, ExecConfig};
+use super::history::{load_current_history, write_history_file, History};
 use super::ipc;
 
 const ZERO_DURATION: Duration = Duration::from_secs(0);
@@ -72,6 +73,11 @@ struct ServerState {
     second_start_cmd: Option<String>,
     /// Verbose reporting
     verbose: bool,
+
+    /// Record of prior runs
+    prior_history: History,
+    /// Log of only the latest results
+    in_the_making: History,
 
     // Metrics
     /// Total bytes of files (TaskOutput) messages returned
@@ -132,6 +138,8 @@ impl ServerState {
             start_cmd,
             second_start_cmd,
             verbose,
+            prior_history: load_current_history(),
+            in_the_making: History::new(),
             total_bytes: 0.bytes(),
             bytes_this_period: 0.bytes(),
             total_run_time: Duration::from_secs(0),

--- a/src/server.rs
+++ b/src/server.rs
@@ -175,7 +175,6 @@ impl ServerState {
 
     /// Record the elapsed of successful tasks for prioritization next time
     fn record_elapsed(self: &mut ServerState, target_id: &str, elapsed: std::time::Duration) {
-        println!("History: {} = {:?}", target_id, elapsed);
         self.in_the_making.update(target_id, elapsed);
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -550,6 +550,7 @@ async fn handle_msg(server_state: &mut ServerState, conn_id: usize, msg: Box<ipc
         }
         ipc::Message::TaskDone {
             exit_code: _,
+            target_id: _,
             run_time,
             send_time,
         } => {

--- a/src/task.rs
+++ b/src/task.rs
@@ -4,7 +4,7 @@ extern crate tempfile;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use tempfile::TempDir;
+use tempfile::{tempdir, TempDir};
 use tokio::process;
 
 #[cfg(test)]
@@ -73,14 +73,18 @@ fn redirect_outputs(args: &mut Vec<String>, output_args: &[u16]) -> Result<(Opti
     if output_args.is_empty() {
         Ok((None, output_files))
     } else {
-        let output_dir = TempDir::new().unwrap();
-        let mut taken_names = std::collections::HashSet::new();
-        for i in output_args {
-            let path = generate_unique_file(&output_dir, &mut taken_names, &args[*i as usize]);
-            args[*i as usize] = path.to_string_lossy().to_string();
-            output_files.push(path);
+        match tempdir() {
+            Ok(output_dir) => {
+                let mut taken_names = std::collections::HashSet::new();
+                for i in output_args {
+                    let path = generate_unique_file(&output_dir, &mut taken_names, &args[*i as usize]);
+                    args[*i as usize] = path.to_string_lossy().to_string();
+                    output_files.push(path);
+                }
+                Ok((Some(output_dir), output_files))
+            }
+            Err(e) => Err(format!("Fatal error: unable to create temporary working directory: {}", e)),
         }
-        Ok((Some(output_dir), output_files))
     }
 }
 
@@ -168,7 +172,7 @@ fn task_unique_paths() {
     let pipe_path;
 
     {
-        let pipe_dir = TempDir::new("spraycc").unwrap();
+        let pipe_dir = tempdir().unwrap();
         pipe_path = pipe_dir.path().to_path_buf();
 
         println!("Temporary directory is: {:?}", pipe_dir.path());

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,10 +1,10 @@
 extern crate gethostname;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tokio::process;
 
 #[cfg(test)]
@@ -73,7 +73,7 @@ fn redirect_outputs(args: &mut Vec<String>, output_args: &[u16]) -> Result<(Opti
     if output_args.is_empty() {
         Ok((None, output_files))
     } else {
-        let output_dir = TempDir::new("spraycc").unwrap();
+        let output_dir = TempDir::new().unwrap();
         let mut taken_names = std::collections::HashSet::new();
         for i in output_args {
             let path = generate_unique_file(&output_dir, &mut taken_names, &args[*i as usize]);


### PR DESCRIPTION
Record the elapsed time of tasks run and use those times to prioritize the queue on future runs. This helps reduce the scheduling tail at the end of runs by starting the longest-running tasks early. 

Dependency tasks (-M and -MM w/ Gnu compilers) are prioritized +300s so that they run ahead of compilation tasks since they typically gate later compilation tasks.
