### PR TITLE
User-level security + automatically raise file descriptor soft limit if possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a9ed03edbed449d6897c2092c71ab5f7b5fb80f6f0b1a3ed6d40a6f9fc0720"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +639,7 @@ dependencies = [
  "lazy_static",
  "priority-queue",
  "rand",
+ "rlimit",
  "serde",
  "serde_json",
  "simple-process-stats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ home = "0.5"
 lazy_static = "1"
 priority-queue = "^1.1"
 rand = "^0.8"
+rlimit = "^0.5"
 serde = { version = "^1", features = ["derive"] }
 serde_json = "1"
 simple-process-stats = "^1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -73,6 +73,8 @@ pub async fn run(args: Vec<String>) -> Result<i32, Box<dyn Error + Send + Sync>>
     }
     let (run_local, task) = res.unwrap();
 
+    let user_private_key = config::load_user_private_key(false /* don't create */);
+
     let mut status: Option<i32> = None;
     if run_local {
         status = run_local_task(task).await?;
@@ -86,6 +88,7 @@ pub async fn run(args: Vec<String>) -> Result<i32, Box<dyn Error + Send + Sync>>
                 // Start by sending the task to the server. This tells the server this process is a client as well as providing the task data.
                 conn.write_message(&ipc::Message::Task {
                     access_code: callme.access_code,
+                    user_code: user_private_key,
                     details: task,
                 })
                 .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate clap;
+extern crate rlimit;
 extern crate tokio;
 
 use clap::{App, AppSettings, Arg, SubCommand};
@@ -98,6 +99,7 @@ async fn main() {
                 )
                 .arg(Arg::with_name("fail").long("fail").help("If present, the exit status is non-zero")),
         )
+        .subcommand(SubCommand::with_name("init").about("Initializes the environment for first-time users"))
         .get_matches();
 
     let res: Result<(), Box<dyn Error + Send + Sync>> = if let Some(server) = matches.subcommand_matches("server") {
@@ -165,6 +167,8 @@ async fn main() {
             panic!("Failing as requested");
         }
         Ok(())
+    } else if let Some(_) = matches.subcommand_matches("init") {
+        initialize_environment()
     } else {
         unreachable!();
     };
@@ -177,4 +181,23 @@ async fn main() {
             1
         }
     });
+}
+
+/// Initializes the environment for first-time users by:
+///   1 - Create a default .spraycc file if it doesn't exist
+///   2 - Create a default .spraycc.private file w/ random user-code if it doesn't exist
+///   3 - Verify the user's environment is otherwise setup correct (enough file descriptors, etc)
+fn initialize_environment() -> Result<(), Box<dyn Error + Send + Sync>> {
+    // Ensure the user has a private key
+    let _ = config::load_user_private_key();
+
+    // Validate the user's rlimit for open file descriptors is high enough
+    if let Ok((soft_limit, _hard_limit)) = rlimit::getrlimit(rlimit::Resource::NOFILE) {
+        println!("Resource limit: {}, {}", soft_limit.as_usize(), _hard_limit);
+        if soft_limit.as_usize() < 2048 {
+            println!("SprayCC: Warning: soft-limit on the number of open file descriptors is {}", soft_limit);
+            println!("         Build parallelism (make -jN or similar) needs to be lower than this, minus the max executors");
+        }
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,8 @@ async fn main() {
 }
 
 /// Initializes the environment for first-time users by:
-///   1 - Create a default .spraycc file if it doesn't exist
-///   2 - Create a default .spraycc.private file w/ random user-code if it doesn't exist
-///   3 - Verify the user's environment is otherwise setup correct (enough file descriptors, etc)
+///   1 - Create a default .spraycc.private file w/ random user-code if it doesn't exist
+///   2 - Verify the user's environment is otherwise setup correct (enough file descriptors, etc)
 fn initialize_environment() -> Result<(), Box<dyn Error + Send + Sync>> {
     // Ensure the user has a private key
     let _ = config::load_user_private_key(true /* create if it doesn't already exist */);

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,7 +20,7 @@ use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant};
 use ubyte::{ByteUnit, ToByteUnit};
 
-use super::config::ExecConfig;
+use super::config;
 use super::history::{load_current_history, write_history_file, History};
 use super::ipc;
 
@@ -68,7 +68,7 @@ struct ServerState {
     /// Timestamp when last activity occured
     last_activity_time: SystemTime,
     /// User configuration parameters
-    user_config: ExecConfig,
+    user_config: config::ExecConfig,
     /// User-specific key to avoid party crashers
     user_private_key: u64,
     /// Exec process start command


### PR DESCRIPTION
Primary changes add a private, per-user key that all of the processes use to verify that remote connections. The key is stored in ~/.spraycc.private w/ no group or other read permissions. The clients and executors must present the correct key to the server to prevent other users from connecting to the wrong server (maliciously as well).

"spraycc init" will create the private key if it doesn't exist and validate that the ulimit on the number of file handles per-process is high enough. If not, it will attempt to raise it to at least 2048, preferably 4096. Lower values limit the number of clients which can connect to the server at once.
  